### PR TITLE
began copy over of lralloc to rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+memmap = "0.7.0"
+bitfield = "0.13.2"

--- a/src/allocation_data.rs
+++ b/src/allocation_data.rs
@@ -1,0 +1,65 @@
+use crate::allocation_data::SuperBlockState::{FULL, PARTIAL, EMPTY};
+
+#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
+pub enum SuperBlockState {
+    FULL,
+    PARTIAL,
+    EMPTY
+}
+
+impl From<u64> for SuperBlockState {
+    fn from(u: u64) -> Self {
+        match u {
+            0 => FULL,
+            1 => PARTIAL,
+            2 => EMPTY,
+            _ => panic!("Not a valid option")
+        }
+    }
+}
+
+impl Into<u64> for SuperBlockState {
+    fn into(self) -> u64 {
+        match self {
+            FULL => { 0 },
+            PARTIAL => { 1 },
+            EMPTY => { 2 },
+        }
+    }
+}
+
+impl Default for Anchor {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
+
+bitfield! {
+    pub struct Anchor(u64);
+    impl Debug;
+    pub from into SuperBlockState, state, set_state: 1, 0;
+    pub avail, set_avail: 2, 31;
+    pub count, set_count: 32, 63;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bitfield::size_of;
+
+    #[test]
+    fn anchor_packed() {
+        assert_eq!(size_of::<Anchor>(), size_of::<u64>())
+    }
+
+    #[test]
+    fn anchor_independent() {
+        let mut anchor = Anchor::default();
+        assert_eq!(anchor.state(), FULL);
+        anchor.set_state(EMPTY);
+        anchor.set_avail(45);
+        assert_eq!(anchor.state(), EMPTY, "{:?} ",anchor);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+#[macro_use] pub mod macros;
+mod size_classes;
+mod mem_info;
+mod allocation_data;
+
+#[macro_use]
+extern crate bitfield;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,23 @@
+
+
+#[macro_export]
+macro_rules! size_class_bin_yes {
+    ($block:expr, $pages:expr) => {
+        SizeClassData {
+            block_size: $block,
+            sb_size: ($pages * $crate::mem_info::PAGE) as u32,
+            block_num: 0,
+            cache_block_num: 0,
+        }
+    };
+}
+
+
+#[macro_export]
+macro_rules! sc {
+    ($index:expr, $lg_grp:expr, $lg_delta:expr, $ndelta:expr, $psz:expr, yes, $pgs:expr, $lg_delta_lookup:expr) => {
+        $crate::size_class_bin_yes!(((1usize << $lg_grp) + ($ndelta << $lg_delta)) as u32, $pgs)
+    };
+}
+
+

--- a/src/mem_info.rs
+++ b/src/mem_info.rs
@@ -1,0 +1,23 @@
+use std::mem::size_of;
+
+pub const MAX_SZ_IDX: usize = 40usize;
+pub const LG_MAX_SIZE_IDX: usize = 6_usize;
+pub const MAX_SZ: usize = (1 << 13) + (1 << 11) * 3;
+pub const LG_PTR: usize = size_of::<*const usize>();
+/// cache line is 64 bytes
+pub const LG_CACHE_LINE: usize = 6;
+/// a Page is is 4kb
+pub const LG_PAGE: usize = 12;
+/// a huge page is 2mb
+pub const LG_HUGE_PAGE: usize = 21;
+
+pub const PTR_SIZE: usize = 1usize << LG_PTR;
+pub const CACHE_LINE: usize = 1usize << LG_CACHE_LINE;
+pub const PAGE: usize = 1usize << LG_PAGE;
+pub const HUGE_PAGE: usize = 1 << LG_HUGE_PAGE;
+
+pub const PTR_MASK: usize = PTR_SIZE - 1;
+pub const CACHE_LINE_MASK: usize = CACHE_LINE - 1;
+pub const PAGE_MASK: usize = (PAGE - 1);
+
+pub const MIN_ALIGN: usize = LG_PTR;

--- a/src/size_classes.rs
+++ b/src/size_classes.rs
@@ -1,0 +1,122 @@
+
+use crate::sc;
+use std::mem::size_of;
+use crate::mem_info::{MAX_SZ, MAX_SZ_IDX, PAGE};
+
+pub struct SizeClassData {
+    pub block_size: u32,
+    pub sb_size: u32,
+    pub block_num: u32,
+    pub cache_block_num: u32,
+}
+
+pub static mut SIZE_CLASS_LOOK_UP: [usize; MAX_SZ + 1] = [0; MAX_SZ + 1];
+#[inline]
+pub fn get_size_class(size: usize) -> usize {
+    unsafe {
+        // using .clone() just in case
+        SIZE_CLASS_LOOK_UP[size].clone()
+    }
+}
+
+pub unsafe fn init_size_class() {
+    // Get the number of blocks in the superblocks to be correct
+    for scIdx in 1..MAX_SZ_IDX {
+        let sc = &mut SIZE_CLASSES[scIdx];
+        let block_size = sc.block_size;
+        let mut sb_size = sc.sb_size;
+        if sb_size > block_size && sb_size % block_size == 0 {
+            continue;
+        }
+
+        // increase the super block size
+        while block_size >= sb_size {
+            sb_size += sc.block_size
+        }
+
+        sc.sb_size = sb_size;
+    }
+
+    // increase super block size if needed
+    for scIdx in 1..MAX_SZ_IDX {
+        let sc = &mut SIZE_CLASSES[scIdx];
+        let mut sb_size = sc.sb_size;
+        while sb_size < (PAGE * PAGE) as u32 {
+            sb_size += sc.sb_size;
+        }
+
+        sc.sb_size = sb_size;
+    }
+
+    // fill in missing fields
+    for scIdx in 1..MAX_SZ_IDX {
+        let sc = &mut SIZE_CLASSES[scIdx];
+
+        sc.block_num = sc.sb_size / sc.block_size;
+        sc.cache_block_num = sc.block_num;
+        assert!(sc.block_num > 0);
+        assert!(sc.block_num >= sc.cache_block_num);
+    }
+
+    // first size reserved
+    let mut lookup_idx = 0;
+    for scIdx in 1..(MAX_SZ_IDX as u32) {
+        let sc = &SIZE_CLASSES[scIdx as usize];
+        let block_size = sc.block_size;
+        while lookup_idx <= block_size {
+            SIZE_CLASS_LOOK_UP[lookup_idx as usize] = scIdx as usize;
+            lookup_idx += 1;
+        }
+    }
+
+}
+// size class data, from jemalloc 5.0
+macro_rules! size_classes {
+    () => {
+        [
+        SizeClassData { block_size: 0, sb_size: 0, block_num: 0, cache_block_num: 0 },
+        $crate::sc!(  0,      3,        3,      0,  no, yes,   1,  3),
+        $crate::sc!(  1,      3,        3,      1,  no, yes,   1,  3),
+        $crate::sc!(  2,      3,        3,      2,  no, yes,   3,  3),
+        $crate::sc!(  3,      3,        3,      3,  no, yes,   1,  3),
+        $crate::sc!(  4,      5,        3,      1,  no, yes,   5,  3),
+        $crate::sc!(  5,      5,        3,      2,  no, yes,   3,  3),
+        $crate::sc!(  6,      5,        3,      3,  no, yes,   7,  3),
+        $crate::sc!(  7,      5,        3,      4,  no, yes,   1,  3),
+        $crate::sc!(  8,      6,        4,      1,  no, yes,   5,  4),
+        $crate::sc!(  9,      6,        4,      2,  no, yes,   3,  4),
+        $crate::sc!( 10,      6,        4,      3,  no, yes,   7,  4),
+        $crate::sc!( 11,      6,        4,      4,  no, yes,   1,  4),
+        $crate::sc!( 12,      7,        5,      1,  no, yes,   5,  5),
+        $crate::sc!( 13,      7,        5,      2,  no, yes,   3,  5),
+        $crate::sc!( 14,      7,        5,      3,  no, yes,   7,  5),
+        $crate::sc!( 15,      7,        5,      4,  no, yes,   1,  5),
+        $crate::sc!( 16,      8,        6,      1,  no, yes,   5,  6),
+        $crate::sc!( 17,      8,        6,      2,  no, yes,   3,  6),
+        $crate::sc!( 18,      8,        6,      3,  no, yes,   7,  6),
+        $crate::sc!( 19,      8,        6,      4,  no, yes,   1,  6),
+        $crate::sc!( 20,      9,        7,      1,  no, yes,   5,  7),
+        $crate::sc!( 21,      9,        7,      2,  no, yes,   3,  7),
+        $crate::sc!( 22,      9,        7,      3,  no, yes,   7,  7),
+        $crate::sc!( 23,      9,        7,      4,  no, yes,   1,  7),
+        $crate::sc!( 24,     10,        8,      1,  no, yes,   5,  8),
+        $crate::sc!( 25,     10,        8,      2,  no, yes,   3,  8),
+        $crate::sc!( 26,     10,        8,      3,  no, yes,   7,  8),
+        $crate::sc!( 27,     10,        8,      4,  no, yes,   1,  8),
+        $crate::sc!( 28,     11,        9,      1,  no, yes,   5,  9),
+        $crate::sc!( 29,     11,        9,      2,  no, yes,   3,  9),
+        $crate::sc!( 30,     11,        9,      3,  no, yes,   7,  9),
+        $crate::sc!( 31,     11,        9,      4, yes, yes,   1,  9),
+        $crate::sc!( 32,     12,       10,      1,  no, yes,   5, no),
+        $crate::sc!( 33,     12,       10,      2,  no, yes,   3, no),
+        $crate::sc!( 34,     12,       10,      3,  no, yes,   7, no),
+        $crate::sc!( 35,     12,       10,      4, yes, yes,   2, no),
+        $crate::sc!( 36,     13,       11,      1,  no, yes,   5, no),
+        $crate::sc!( 37,     13,       11,      2, yes, yes,   3, no),
+        $crate::sc!( 38,     13,       11,      3,  no, yes,   7, no)]
+
+
+    };
+}
+
+pub static mut SIZE_CLASSES: [SizeClassData; MAX_SZ_IDX] = size_classes!();


### PR DESCRIPTION
The bitfield package allows for the anchor structure to be exactly 64 bits long while having the different fields, and use rust style enums to get and set the state field.

C++ struct:
```c++
struct Anchor
{
    uint32_t state : 2;
    uint32_t avail : LG_MAX_BLOCK_NUM;
    uint32_t count : LG_MAX_BLOCK_NUM;
} LFMALLOC_ATTR(packed);
```
Rust equivalent using the bitfield package:
```rust
bitfield! {
    pub struct Anchor(u64);
    impl Debug;
    pub from into SuperBlockState, state, set_state: 1, 0;
    pub avail, set_avail: 2, 31;
    pub count, set_count: 32, 63;
}
```

> They appear